### PR TITLE
📝 Updating OpenAI links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Some advantages of using TerminalGPT:
 
 - Python 3.6 or higher
 - An OpenAI Account and API key.
-  1.  Sign up at <https://beta.openai.com/signup> using email or Google/Microsoft account.
-  2.  Go to <https://beta.openai.com/account/api-keys> or click on "View API keys" in the menu to get your API key.
+  1.  Sign up at <https://platform.openai.com/signup> using email or Google/Microsoft account.
+  2.  Go to <https://platform.openai.com/account/api-keys> or click on "View API keys" in the menu to get your API key.
 
 ## Installation
 

--- a/terminalgpt/printer.py
+++ b/terminalgpt/printer.py
@@ -112,8 +112,8 @@ class PrintUtils:
         + Style.RESET_ALL
         + """
 Please note that you need to have an OpenAI account and an API key to use TerminalGPT.
-If you don't have an OpenAI account, please create one at https://beta.openai.com/signup.
-If you don't have an API key, please create one at https://beta.openai.com/account/api-keys.
+If you don't have an OpenAI account, please create one at https://platform.openai.com/signup.
+If you don't have an API key, please create one at https://platform.openai.com/api-keys.
 """
         + Style.BRIGHT
         + Fore.LIGHTBLUE_EX


### PR DESCRIPTION
Domain `beta.openai.com` seems to be outdated, the current domain is `platform.openai.com`