### PR TITLE
👷 Adding Dockerfile & Docker usage docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.13-alpine
+
+RUN pip install terminalgpt
+
+ENTRYPOINT ["terminalgpt"]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ rm "$package_location"
 pipx install terminalgpt==2.2.7 --force
 ```
 
+### Using Docker
+
+1. Pull the image.
+
+```sh
+docker pull adamyodinsky/terminalgpt
+```
+
+2. Use the image, mounting the configuration directory as a volume.
+
+```sh
+docker run --rm -it -v $HOME/.terminalgpt:/root/.terminalgpt adamyodinsky/terminalgpt terminalgpt install
+```
+
+See [Recommended aliases](#recommended-aliases) for shell aliases that make the Docker commands shorter.
+
 ### Setup
 
 1. Now you have `terminalgpt` command available in your terminal. Run the following install command to configure the app.
@@ -166,6 +182,16 @@ echo alias tgptn="terminalgpt new" >> ~/.zshrc
 echo alias tgpt="terminalgpt" >> ~/.bashrc
 echo alias tgpto="terminalgpt one-shot" >> ~/.bashrc
 echo alias tgptn="terminalgpt new" >> ~/.bashrc
+```
+
+### Docker
+
+Here's an example of Bash aliases for using the Docker image:
+
+```sh
+echo alias tgpt="docker run --rm -it -v $HOME/.terminalgpt:/root/.terminalgpt adamyodinsky/terminalgpt" >> ~/.bashrc
+echo alias tgpto="docker run --rm -it -v $HOME/.terminalgpt:/root/.terminalgpt adamyodinsky/terminalgpt one-shot" >> ~/.bashrc
+echo alias tgptn="docker run --rm -it -v $HOME/.terminalgpt:/root/.terminalgpt adamyodinsky/terminalgpt new" >> ~/.bashrc
 ```
 
 ---


### PR DESCRIPTION
Note: This is just an idea and will need additional work before it could be merged (if maintainers even want to go this way).

Some of us (like me) are not Python developers and don't want to figure out the Python versions and/or virtual envs for PIP installation. I'm suggesting to add Docker as another way of running TerminalGPT, which could be easier for such users. It is also way easier to support than proper package managers, because there's just too many (brew, deb, snap, don't even get me started about Windows).

Obviously this requires some additional work from the maintainers, namely pushing the `adamyodinsky/terminalgpt` image with each release. This CAN be automated with Github Actions, I can help if needed