### PR TITLE
Resolve CI Pipeline Failing

### DIFF
--- a/terminalgpt/main.py
+++ b/terminalgpt/main.py
@@ -217,7 +217,7 @@ def new(ctx):
     )
 
     messages = [config.INIT_SYSTEM_MESSAGE]
-    chat_manager.welcome_message(messages + [config.INIT_WELCOME_MESSAGE])    
+    chat_manager.welcome_message(messages + [config.INIT_WELCOME_MESSAGE])
     chat_manager.messages = messages
     chat_manager.chat_loop()
 


### PR DESCRIPTION
Simple CI fail resolution because the score is not 10/10.
- Remove trailing whitespace upsetting pylint
